### PR TITLE
Fixes function undefined due to webpack mix js

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "scripts": {
     "build": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "build:prod": "cross-env NODE_ENV=production webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "watch": "cross-env sync=1 NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
     "lint": "npm run lint:styles && npm run lint:scripts && npm run lint:php",
     "lint:styles": "cross-env stylelint './assets/scss/**/*.scss' --syntax scss",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -80,10 +80,10 @@ mix.version();
  * @link https://laravel.com/docs/5.6/mix#working-with-scripts
  */
 mix
-    .js([
+    .scripts([
         `${devPath}/js/editor.js`
-    ], `${devPath}/js/min`)
-    .js([
+    ], `${devPath}/js/min/editor.js`)
+    .scripts([
         `${devPath}/js/hide-show.js`,
         `${devPath}/js/sticky-header.js`,
         `${devPath}/js/smooth-scroll.js`


### PR DESCRIPTION
Fix for Uncaught ReferenceError: show is not defined

laravel mix js minifed changes function names, causing the function calls to result in unknown. changing mix js with mix scripts fixes the output. 

also including npm run build:prod for final minified version of js